### PR TITLE
feat: checkoutステップのrefオプションをGitHub Actionsから削除

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,6 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+      time: "06:00"
+      timezone: "Asia/Tokyo"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,24 +15,19 @@ jobs:
       actions: read
       contents: read
       security-events: write
-
     strategy:
       fail-fast: false
       matrix:
         language: [ 'javascript' ]
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
-
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: [pull_request]
+on:
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   setup:
@@ -9,8 +11,6 @@ jobs:
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v3
         with:
           node-version: 18
@@ -36,8 +36,6 @@ jobs:
       - setup
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v3
         with:
           node-version: 18


### PR DESCRIPTION
# やったこと

- checkoutステップのrefオプションをGitHub Actionsから削除
- 毎日6時にdependabotが実行されるよう設定

# やらなかったこと

- なし

# 補足

- なし
